### PR TITLE
Make tests pass

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,8 @@ requires 'MooseX::AttributeHelpers'   => 0;
 requires 'MooseX::Traits'             => '0.06';
 requires 'MooseX::Params::Validate'   => 0;
 
+requires 'MRO::Compat'                => 0;
+
 requires 'Try::Tiny'                  => 0;
 requires 'Set::Object'                => 0;
 requires 'JSON::RPC::Common'          => '0.05';

--- a/lib/Catalyst/Action/JSORB.pm
+++ b/lib/Catalyst/Action/JSORB.pm
@@ -7,13 +7,15 @@ our $AUTHORITY = 'cpan:STEVAN';
 use JSORB;
 use JSON::RPC::Common::Marshal::HTTP;
 
+use MRO::Compat;
+
 extends 'Catalyst::Action';
 
 sub execute {
     my $self = shift;
     my ($controller, $c) = @_;
 
-    $self->NEXT::execute(@_);
+    $self->next::method(@_);
 
     # try local, but if none exists, use global
     my $dispatcher = $controller->config->{'Action::JSORB'} || $c->config->{'Action::JSORB'};

--- a/lib/Catalyst/Action/JSORB/WithInvocant.pm
+++ b/lib/Catalyst/Action/JSORB/WithInvocant.pm
@@ -7,13 +7,15 @@ our $AUTHORITY = 'cpan:STEVAN';
 use JSORB;
 use JSON::RPC::Common::Marshal::HTTP;
 
+use MRO::Compat;
+
 extends 'Catalyst::Action';
 
 sub execute {
     my $self = shift;
     my ($controller, $c) = @_;
 
-    $self->NEXT::execute(@_);
+    $self->next::method(@_);
 
     # try local, but if none exists, use global
     my $dispatcher = $controller->config->{'Action::JSORB'} || $c->config->{'Action::JSORB'};

--- a/t/040_class_reflector.t
+++ b/t/040_class_reflector.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 26;
+use Test::More tests => 14;
 use Test::Exception;
 
 use JSON::RPC::Common::Procedure::Call;
@@ -39,7 +39,7 @@ isa_ok($d, 'JSORB::Dispatcher::Path');
 my $point = My::Point->new(x => 10);
 isa_ok($point, 'My::Point');
 
-{
+subtest '/my/point/x' => sub {
     my $call = JSON::RPC::Common::Procedure::Call->new(
         method => "/my/point/x",
         params => [],
@@ -52,11 +52,11 @@ isa_ok($point, 'My::Point');
     ok(!$res->has_error, '... we have a result, not an error');
 
     is($res->result, 10, '... got the result we expected');
-}
+};
 
 is($point->x, 10, '... our object has been altered successfully');
 
-{
+subtest '/my/point/x?params=[100]' => sub {
     my $call = JSON::RPC::Common::Procedure::Call->new(
         method => "/my/point/x",
         params => [100],
@@ -69,11 +69,11 @@ is($point->x, 10, '... our object has been altered successfully');
     ok(!$res->has_error, '... we have a result, not an error');
 
     is($res->result, 100, '... got the result we expected');
-}
+};
 
 is($point->x, 100, '... our object has been altered successfully');
 
-{
+subtest '/my/point/y?params=[200]' => sub {
     my $call = JSON::RPC::Common::Procedure::Call->new(
         method => "/my/point/y",
         params => [200],
@@ -86,21 +86,21 @@ is($point->x, 100, '... our object has been altered successfully');
     ok(!$res->has_error, '... we have a result, not an error');
 
     is($res->result, 200, '... got the result we expected');
-}
+};
 
 is($point->y, 200, '... our object has been altered successfully');
 
-{
+subtest '/my/point/inexistent/', => sub {
     my $call = JSON::RPC::Common::Procedure::Call->new(
-        method => "/my/point/isa",
+        method => "/my/point/inexistent",
         params => ['My::Point'],
     );
-    
+
     my $res = $d->handler($call, $point);
     isa_ok($res, 'JSON::RPC::Common::Procedure::Return');
 
-    ok(!$res->has_result, '... we have a result, not an error');
-    ok($res->has_error, '... we have a result, not an error');
+    ok !$res->has_result, 'not a result';
+    ok $res->has_error, 'but an error';
 
-    like($res->error->message, qr/Could not find method \/my\/point\/isa/, '... got the right error');
-}
+    like($res->error->message, qr/Could not find method \/my\/point\/inexistent/, '... got the right error');
+};

--- a/t/042_class_reflector_with_inheritance.t
+++ b/t/042_class_reflector_with_inheritance.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 43;
+use Test::More tests => 40;
 use Test::Exception;
 
 use JSON::RPC::Common::Procedure::Call;
@@ -145,9 +145,9 @@ is($point->z, 200, '... our object has been altered successfully');
 
 is($point->y, 200, '... our object has been altered successfully');
 
-{
+subtest 'inexistant method' => sub {
     my $call = JSON::RPC::Common::Procedure::Call->new(
-        method => "/my/point3d/isa",
+        method => "/my/point3d/inexistant",
         params => ['My::Point'],
     );
     
@@ -157,8 +157,8 @@ is($point->y, 200, '... our object has been altered successfully');
     ok(!$res->has_result, '... we have a result, not an error');
     ok($res->has_error, '... we have a result, not an error');
 
-    like($res->error->message, qr/Could not find method \/my\/point3d\/isa/, '... got the right error');
-}
+    like($res->error->message, qr/Could not find method \/my\/point3d\/inexistant/, '... got the right error');
+};
 
 {
     my $call = JSON::RPC::Common::Procedure::Call->new(

--- a/t/300_catalyst_action.t
+++ b/t/300_catalyst_action.t
@@ -8,10 +8,12 @@ use lib "$FindBin::Bin/lib";
 
 use Test::More;
 
+use JSON qw/ from_json /;
+
 BEGIN {
     eval "use Catalyst;";
-    plan skip_all => "Catalyst is required for this test" if $@;        
-    plan tests => 30;    
+    plan skip_all => "Catalyst is required for this test" if $@;
+    plan tests => 18;
 }
 
 use Catalyst::Test 'TestApp';
@@ -26,7 +28,10 @@ use Catalyst::Test 'TestApp';
     is($response->header( 'Content-Type' ), 'application/json-rpc', '... got the JSON content-type');    
     is($response->code, 200, '.. response code is 200');
        
-    is($response->content, '{"jsonrpc":"2.0","result":"Hello World"}', '... got the content we expected');
+    is_deeply( from_json( $response->content ), {
+        jsonrpc => "2.0",
+        result => "Hello World"
+    }, '... got the content we expected');
 }
 
 
@@ -40,7 +45,9 @@ use Catalyst::Test 'TestApp';
     is($response->header( 'Content-Type' ), 'application/json-rpc', '... got the JSON content-type');    
     is($response->code, 200, '.. response code is 200');
        
-    is($response->content, '{"jsonrpc":"2.0","result":"Yo! What\'s up Man"}', '... got the content we expected');
+    is_deeply( from_json($response->content), {
+        jsonrpc => "2.0", result => "Yo! What's up Man"
+    }, '... got the content we expected');
 }
 
 {
@@ -53,10 +60,15 @@ use Catalyst::Test 'TestApp';
     is($response->header( 'Content-Type' ), 'application/json-rpc', '... got the JSON content-type');    
     is($response->code, 200, '.. response code is 200');
        
-    is($response->content, '{"jsonrpc":"2.0","result":"Hey! What\'s up Man"}', '... got the content we expected');
+    is_deeply( from_json( $response->content ) => {
+            jsonrpc => '2.0',
+            result => "Hey! What's up Man",
+        },
+        "got the expected content",
+    );
 }
 
-foreach my $i (1 .. 3) {
+foreach my $i (1 .. 3) { subtest "FOO::BAR($i)" => sub {
     my $request = HTTP::Request->new( 
         GET => 'http://localhost:3000/foo/rpc?method=/test/app/foo/bar&params=[]' 
     );
@@ -66,6 +78,9 @@ foreach my $i (1 .. 3) {
     is($response->header( 'Content-Type' ), 'application/json-rpc', '... got the JSON content-type');    
     is($response->code, 200, '.. response code is 200');
        
-    is($response->content, '{"jsonrpc":"2.0","result":"FOO::BAR(' . $i . ')"}', '... got the content we expected');
-}
+    is_deeply(
+        from_json($response->content), { jsonrpc => "2.0", result => "FOO::BAR($i)"}, 
+            '... got the content we expected'
+    );
+} }
 


### PR DESCRIPTION
This patch addresses 3 issues:
- some tests were using 'isa' assuming it's a method that doesn't exist. It does.
- Some tests were assuming hashes to be ordered. Tsk. Tsk. ;-)
- NEXT is now deprecated in favor of MRO::Compat.
